### PR TITLE
Handle remote files via TRAMP

### DIFF
--- a/find-file-in-git-repo.el
+++ b/find-file-in-git-repo.el
@@ -15,7 +15,10 @@
 (defun find-file-in-git-repo ()
   (interactive)
   (let* ((repo (find-git-repo default-directory))
-         (files (shell-command-to-string (format "cd %s && git ls-files" repo))))
+         (local-repo (if (tramp-tramp-file-p repo)
+                         (tramp-file-name-localname (tramp-dissect-file-name repo))
+                       repo))
+         (files (shell-command-to-string (format "cd %s && git ls-files" local-repo))))
     (find-file
      (concat repo
              (ido-completing-read


### PR DESCRIPTION
Without this change, invoking find-file-in-git-repo from a remote directory fails and prints a nonsense prompt.