### PR TITLE
Support git-worktree

### DIFF
--- a/find-file-in-git-repo.el
+++ b/find-file-in-git-repo.el
@@ -29,7 +29,7 @@
 (defun find-git-repo (dir)
   (if (string= "/" dir)
       (message "not in a git repo.")
-    (if (file-exists-p (expand-file-name ".git/" dir))
+    (if (file-exists-p (expand-file-name ".git" dir))
         dir
       (find-git-repo (expand-file-name "../" dir)))))
 


### PR DESCRIPTION
git-worktree creates working copies containing `.git` files, rather than `.git` directories, e.g.

```
$ cat .git
gitdir: /Users/Shared/dabrahams/s/swift/.git/worktrees/swift-master
$
``` 

Everything seems to work fine there if we just drop the slash.